### PR TITLE
Update schedules_sync.yml upstream branch to main

### DIFF
--- a/.github/workflows/schedules_sync.yml
+++ b/.github/workflows/schedules_sync.yml
@@ -11,7 +11,7 @@ name: Merge upstream branches
 on:
   # Runs on 10 minutes past every hour（毎 n 時 10 分に実行）
   schedule:
-    # Ref:
+    # Ref: 
     #   - https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
     #   - https://crontab.guru/examples.html
     # Cron format:
@@ -20,11 +20,11 @@ on:
     #         │ │ ┌───────────── day of the month (1 - 31)
     #         │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #         │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #         │ │ │ │ │
+    #         │ │ │ │ │                                   
     #         │ │ │ │ │
     #         │ │ │ │ │
     #         * * * * *
-    - cron: "0 10/1 * * *"
+    - cron:  '0 10/1 * * *'
 
 jobs:
   merge:
@@ -41,7 +41,7 @@ jobs:
         run: |
           git config --global user.name ${NAME}
           git config --global user.email ${EMAIL}
-
+          
           : # git rebase をデフォルトに設定
           git config --global pull.rebase merges
 
@@ -52,12 +52,12 @@ jobs:
 
           : # フォーク元のリポジトリをリモート先として "upstream" に命名
           git remote add upstream ${REPO_FORK}
-
+          
           : # upstream のブランチをローカルに取得
           git fetch upstream
-
+          
           : # main ブランチの変更をマージし、clone 元の main に push
-          : # ブランチ名を他に変更していたり、別のブランチにしている場合は注意
+          : # ブランチ名を main などに変更していたり、別のブランチにしている場合は注意
           git checkout main
           git merge --no-edit upstream/main
           git push origin main

--- a/.github/workflows/schedules_sync.yml
+++ b/.github/workflows/schedules_sync.yml
@@ -1,6 +1,6 @@
 # Follow Changes of Forked/Upstream Repository.
 #
-# This workflow rebase-marge changes from upstream's master to origin's master. 
+# This workflow rebase-marge changes from upstream's main to origin's main.
 # - Ref:
 #   - https://stackoverflow.com/a/61574295/12102603 by N1ngu @ StackOverflow (EN)
 #   - https://qiita.com/KEINOS/items/3bcaa6cea853f6b63475 by KEINOS @ Qiita (JA)
@@ -11,7 +11,7 @@ name: Merge upstream branches
 on:
   # Runs on 10 minutes past every hour（毎 n 時 10 分に実行）
   schedule:
-    # Ref: 
+    # Ref:
     #   - https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
     #   - https://crontab.guru/examples.html
     # Cron format:
@@ -20,11 +20,11 @@ on:
     #         │ │ ┌───────────── day of the month (1 - 31)
     #         │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #         │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #         │ │ │ │ │                                   
+    #         │ │ │ │ │
     #         │ │ │ │ │
     #         │ │ │ │ │
     #         * * * * *
-    - cron:  '0 10/1 * * *'
+    - cron: "0 10/1 * * *"
 
 jobs:
   merge:
@@ -41,23 +41,23 @@ jobs:
         run: |
           git config --global user.name ${NAME}
           git config --global user.email ${EMAIL}
-          
+
           : # git rebase をデフォルトに設定
           git config --global pull.rebase merges
 
-          : # "git checkout master" は不要です。デフォルトで設定されます。
+          : # "git checkout main" は不要です。デフォルトで設定されます。
           : # しかし下記の設定は重要です。過去のコミットが取得されないと、コミット歴に不統合が
           : # 発生した旨のエラーが出ます。
           git pull --unshallow
 
           : # フォーク元のリポジトリをリモート先として "upstream" に命名
           git remote add upstream ${REPO_FORK}
-          
+
           : # upstream のブランチをローカルに取得
           git fetch upstream
-          
-          : # marster ブランチの変更をマージし、clone 元の master に push
-          : # ブランチ名を main などに変更していたり、別のブランチにしている場合は注意
-          git checkout master
-          git merge --no-edit upstream/master
-          git push origin master
+
+          : # main ブランチの変更をマージし、clone 元の main に push
+          : # ブランチ名を他に変更していたり、別のブランチにしている場合は注意
+          git checkout main
+          git merge --no-edit upstream/main
+          git push origin main


### PR DESCRIPTION
## Summary
- update schedules_sync.yml to merge from `main` instead of `master`

## Testing
- `npm run format:check` *(fails: Code style issues found)*
- `npm test` *(fails to run all tests: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68581f3ed39c8330b303edc633290e69